### PR TITLE
[fix] args of `new`

### DIFF
--- a/go/aias_go.h
+++ b/go/aias_go.h
@@ -1,4 +1,4 @@
-void new(const char *signer_privkey, const char *signer_pubkey);
+void new(const char *signer_privkey, const char *signer_pubkey, const char *judge_pubkey);
 void destroy();
 
 void set_blinded_digest(const char *blinded_digest);


### PR DESCRIPTION
Function `new` expects three args, but in header file, it has two